### PR TITLE
Add solutions for q21-24

### DIFF
--- a/proc.sql
+++ b/proc.sql
@@ -350,3 +350,33 @@ BEGIN
     AND (date session_date + time end_time) < INTERVAL '0'; -- Course session hasn't started
 END;
 $$ LANGUAGE plpgsql;
+
+/*
+  Q24: Add a new session to a course offering
+*/
+CREATE OR REPLACE PROCEDURE add_session(input_courseId INT, input_launchDate DATE, input_sessionId INT, input_sessionDate DATE,
+                                        input_sessionStart INT, input_instructorId INT, input_roomId INT)
+AS $$
+DECLARE
+    registrationDeadline DATE;
+    endHour INT;
+BEGIN
+    registrationDeadline := (SELECT registration_deadline
+                             FROM CourseOfferings
+                             WHERE course_id = input_courseId;
+                             AND launch_date = input_launchDate);
+    
+    endHour := input_sessionStart + (SELECT duration 
+                                     FROM Courses
+                                     WHERE course_id = input_courseId);
+
+    /*Course offering registration deadline passed*/
+    IF registrationDeadline < CURRENT_DATE THEN
+        RETURN:
+    END IF;
+
+    /*Check session constraints*/
+    INSERT INTO CourseOfferingSessions
+    VALUES (number, input_sessionStart, endHour, input_roomId, input_instructorId, input_courseId, input_sessionDate, input_launchDate);
+END;
+$$ LANGUAGE plpgsql;

--- a/project.sql
+++ b/project.sql
@@ -179,6 +179,7 @@ CREATE TABLE Redeems (
     PRIMARY KEY (redeems_date, buys_date, sid, cust_id, number, package_id)
 );
 
+-- TODO: Update naming convention to PascalCase instead of snake_case or vice versa for CourseOfferingSessions?
 -- DONE
 CREATE TABLE Pay_slips (
     payment_date                    DATE,

--- a/project.sql
+++ b/project.sql
@@ -125,6 +125,7 @@ CREATE TABLE Buys (
 CREATE TABLE Registers (
     registers_date                  DATE,
     cust_id                         INT REFERENCES Customers(cust_id),
+    sid                             INT REFERENCES CourseOfferingSessions(sid), -- Needed to determine number of registrations for a session
     number                          VARCHAR(16) REFERENCES Credit_cards(number),
     PRIMARY KEY(registers_date, cust_id, number)
 );


### PR DESCRIPTION
I intend to make multiple PRs for the solutions to keep the PRs smaller and easier to update!

P.S Should we rename the schema table for either `CourseOfferingSessions` and `CourseOfferings` to use snake_case? Or rename those using snake_case (e.g `Pay_slips`) to use PascalCase? This is for consistency.